### PR TITLE
Feature ETP-3630: grant access to agents to client-admin roles on load

### DIFF
--- a/src-test/src/com/etendoerp/copilot/util/AgentAccessUtilsTest.java
+++ b/src-test/src/com/etendoerp/copilot/util/AgentAccessUtilsTest.java
@@ -1,0 +1,180 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.copilot.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.criterion.Criterion;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openbravo.base.provider.OBProvider;
+import org.openbravo.dal.service.OBCriteria;
+import org.openbravo.dal.service.OBDal;
+import org.openbravo.model.ad.access.Role;
+import org.openbravo.model.ad.system.Client;
+import org.openbravo.model.common.enterprise.Organization;
+
+import com.etendoerp.copilot.data.CopilotApp;
+import com.etendoerp.copilot.data.CopilotRoleApp;
+
+/**
+ * Unit tests for {@link AgentAccessUtils}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AgentAccessUtilsTest {
+
+  @Mock
+  private Role mockRole;
+  @Mock
+  private Client mockClient;
+  @Mock
+  private Organization mockOrg;
+
+  /** Makes {@code mockRole} an eligible, active, non-System client-admin role. */
+  private void makeEligible() {
+    when(mockRole.isClientAdmin()).thenReturn(Boolean.TRUE);
+    when(mockRole.isActive()).thenReturn(Boolean.TRUE);
+    when(mockRole.getClient()).thenReturn(mockClient);
+    when(mockClient.getId()).thenReturn("ABC123");
+  }
+
+  @Test
+  public void skipsNonClientAdminRole() {
+    when(mockRole.isClientAdmin()).thenReturn(Boolean.FALSE);
+
+    try (MockedStatic<OBDal> obDal = mockStatic(OBDal.class)) {
+      int created = AgentAccessUtils.ensureSharedAgentsGranted(mockRole);
+
+      assertEquals(0, created);
+      obDal.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  public void skipsSystemClientRole() {
+    when(mockRole.isClientAdmin()).thenReturn(Boolean.TRUE);
+    when(mockRole.isActive()).thenReturn(Boolean.TRUE);
+    when(mockRole.getClient()).thenReturn(mockClient);
+    when(mockClient.getId()).thenReturn("0");
+
+    try (MockedStatic<OBDal> obDal = mockStatic(OBDal.class)) {
+      int created = AgentAccessUtils.ensureSharedAgentsGranted(mockRole);
+
+      assertEquals(0, created);
+      obDal.verifyNoInteractions();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void grantsOnlyTheMissingSharedAgents() {
+    makeEligible();
+    when(mockRole.getOrganization()).thenReturn(mockOrg);
+
+    CopilotApp a1 = mock(CopilotApp.class);
+    CopilotApp a2 = mock(CopilotApp.class);
+    when(a1.getId()).thenReturn("app-1");
+    when(a2.getId()).thenReturn("app-2");
+
+    // Role already has a1 granted; a2 is missing.
+    CopilotRoleApp existingGrant = mock(CopilotRoleApp.class);
+    when(existingGrant.getCopilotApp()).thenReturn(a1);
+
+    OBCriteria<CopilotApp> appCrit = mock(OBCriteria.class);
+    OBCriteria<CopilotRoleApp> raCrit = mock(OBCriteria.class);
+    CopilotRoleApp newGrant = mock(CopilotRoleApp.class);
+
+    try (MockedStatic<OBDal> obDal = mockStatic(OBDal.class);
+         MockedStatic<OBProvider> obProvider = mockStatic(OBProvider.class)) {
+      OBDal dal = mock(OBDal.class);
+      OBProvider provider = mock(OBProvider.class);
+      obDal.when(OBDal::getInstance).thenReturn(dal);
+      obProvider.when(OBProvider::getInstance).thenReturn(provider);
+
+      when(dal.createCriteria(CopilotApp.class)).thenReturn(appCrit);
+      when(appCrit.add(any(Criterion.class))).thenReturn(appCrit);
+      when(appCrit.list()).thenReturn(Arrays.asList(a1, a2));
+
+      when(dal.createCriteria(CopilotRoleApp.class)).thenReturn(raCrit);
+      when(raCrit.add(any(Criterion.class))).thenReturn(raCrit);
+      when(raCrit.list()).thenReturn(Collections.singletonList(existingGrant));
+
+      when(provider.get(CopilotRoleApp.class)).thenReturn(newGrant);
+
+      int created = AgentAccessUtils.ensureSharedAgentsGranted(mockRole);
+
+      assertEquals(1, created);
+      verify(newGrant).setCopilotApp(a2);
+      verify(newGrant).setRole(mockRole);
+      verify(newGrant).setClient(mockClient);
+      verify(newGrant).setOrganization(mockOrg);
+      verify(dal, times(1)).save(newGrant);
+      verify(dal, times(1)).flush();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void noOpAndNoFlushWhenAllSharedAgentsAlreadyGranted() {
+    makeEligible();
+
+    CopilotApp a1 = mock(CopilotApp.class);
+    when(a1.getId()).thenReturn("app-1");
+
+    CopilotRoleApp existingGrant = mock(CopilotRoleApp.class);
+    when(existingGrant.getCopilotApp()).thenReturn(a1);
+
+    OBCriteria<CopilotApp> appCrit = mock(OBCriteria.class);
+    OBCriteria<CopilotRoleApp> raCrit = mock(OBCriteria.class);
+
+    try (MockedStatic<OBDal> obDal = mockStatic(OBDal.class);
+         MockedStatic<OBProvider> obProvider = mockStatic(OBProvider.class)) {
+      OBDal dal = mock(OBDal.class);
+      obDal.when(OBDal::getInstance).thenReturn(dal);
+
+      when(dal.createCriteria(CopilotApp.class)).thenReturn(appCrit);
+      when(appCrit.add(any(Criterion.class))).thenReturn(appCrit);
+      when(appCrit.list()).thenReturn(Collections.singletonList(a1));
+
+      when(dal.createCriteria(CopilotRoleApp.class)).thenReturn(raCrit);
+      when(raCrit.add(any(Criterion.class))).thenReturn(raCrit);
+      when(raCrit.list()).thenReturn(Collections.singletonList(existingGrant));
+
+      int created = AgentAccessUtils.ensureSharedAgentsGranted(mockRole);
+
+      assertEquals(0, created);
+      verify(dal, never()).save(any());
+      verify(dal, never()).flush();
+      // Provider is never touched when there is nothing to create.
+      obProvider.verifyNoInteractions();
+    }
+  }
+}

--- a/src-test/src/com/etendoerp/copilot/util/AgentAccessUtilsTest.java
+++ b/src-test/src/com/etendoerp/copilot/util/AgentAccessUtilsTest.java
@@ -66,6 +66,7 @@ public class AgentAccessUtilsTest {
     when(mockClient.getId()).thenReturn("ABC123");
   }
 
+  /** A non client-admin role is skipped: nothing is created and OBDal is never touched. */
   @Test
   public void skipsNonClientAdminRole() {
     when(mockRole.isClientAdmin()).thenReturn(Boolean.FALSE);
@@ -78,6 +79,7 @@ public class AgentAccessUtilsTest {
     }
   }
 
+  /** A client-admin role of the System client (id "0") is skipped and OBDal is never touched. */
   @Test
   public void skipsSystemClientRole() {
     when(mockRole.isClientAdmin()).thenReturn(Boolean.TRUE);
@@ -93,6 +95,7 @@ public class AgentAccessUtilsTest {
     }
   }
 
+  /** Only the shared agents not yet granted are created; already-granted ones are left untouched. */
   @SuppressWarnings("unchecked")
   @Test
   public void grantsOnlyTheMissingSharedAgents() {
@@ -141,6 +144,7 @@ public class AgentAccessUtilsTest {
     }
   }
 
+  /** When every shared agent is already granted, nothing is created, saved or flushed. */
   @SuppressWarnings("unchecked")
   @Test
   public void noOpAndNoFlushWhenAllSharedAgentsAlreadyGranted() {

--- a/src/com/etendoerp/copilot/rest/RestServiceUtil.java
+++ b/src/com/etendoerp/copilot/rest/RestServiceUtil.java
@@ -985,7 +985,7 @@ public class RestServiceUtil {
       // Ensure this client-admin role has access to the shared agents, granting any that are
       // missing on the first assistants load. Idempotent and short-circuited (a single query
       // once complete); wrapped so it never breaks the listing.
-      grantSharedAgentsSafely(role);
+      AgentAccessUtils.ensureSharedAgentsGrantedSafely(role);
 
       List<CopilotApp> appList = new HashSet<>(OBDal.getInstance().createCriteria(CopilotRoleApp.class).add(
           Restrictions.eq(CopilotRoleApp.PROPERTY_ROLE, role)).list()).stream().map(
@@ -1033,28 +1033,6 @@ public class RestServiceUtil {
       }
     }
   }
-
-  /**
-   * Grants the shared Copilot agents to {@code role} without ever aborting the assistants
-   * listing. Any failure is logged and swallowed so a grant problem cannot break the endpoint;
-   * the grants are simply retried on the next load.
-   *
-   * @param role
-   *     the role requesting its assistants
-   */
-  private static void grantSharedAgentsSafely(Role role) {
-    try {
-      int created = AgentAccessUtils.ensureSharedAgentsGranted(role);
-      if (created > 0) {
-        log.info("Granted {} shared Copilot agent(s) to client-admin role '{}'", created,
-            role.getId());
-      }
-    } catch (Exception e) {
-      log.error("Error granting shared Copilot agents to role '{}': {}",
-          role != null ? role.getId() : null, e.getMessage(), e);
-    }
-  }
-
 
   /**
    * This method is used to save a file in the temp folder of the server. The file is saved with a

--- a/src/com/etendoerp/copilot/rest/RestServiceUtil.java
+++ b/src/com/etendoerp/copilot/rest/RestServiceUtil.java
@@ -64,6 +64,7 @@ import com.etendoerp.copilot.data.CopilotAppSource;
 import com.etendoerp.copilot.data.CopilotFile;
 import com.etendoerp.copilot.data.CopilotRoleApp;
 import com.etendoerp.copilot.hook.CopilotQuestionHookManager;
+import com.etendoerp.copilot.util.AgentAccessUtils;
 import com.etendoerp.copilot.util.CopilotConstants;
 import com.etendoerp.copilot.util.CopilotModelUtils;
 import com.etendoerp.copilot.util.CopilotUtils;
@@ -981,6 +982,11 @@ public class RestServiceUtil {
       OBContext context = OBContext.getOBContext();
       Role role = context.getRole();
 
+      // Ensure this client-admin role has access to the shared agents, granting any that are
+      // missing on the first assistants load. Idempotent and short-circuited (a single query
+      // once complete); wrapped so it never breaks the listing.
+      grantSharedAgentsSafely(role);
+
       List<CopilotApp> appList = new HashSet<>(OBDal.getInstance().createCriteria(CopilotRoleApp.class).add(
           Restrictions.eq(CopilotRoleApp.PROPERTY_ROLE, role)).list()).stream().map(
           CopilotRoleApp::getCopilotApp).distinct().collect(Collectors.toList());
@@ -1025,6 +1031,27 @@ public class RestServiceUtil {
       } catch (Exception e) {
         log.error("Error assigning webhook permissions for app '{}': {}", app.getName(), e.getMessage(), e);
       }
+    }
+  }
+
+  /**
+   * Grants the shared Copilot agents to {@code role} without ever aborting the assistants
+   * listing. Any failure is logged and swallowed so a grant problem cannot break the endpoint;
+   * the grants are simply retried on the next load.
+   *
+   * @param role
+   *     the role requesting its assistants
+   */
+  private static void grantSharedAgentsSafely(Role role) {
+    try {
+      int created = AgentAccessUtils.ensureSharedAgentsGranted(role);
+      if (created > 0) {
+        log.info("Granted {} shared Copilot agent(s) to client-admin role '{}'", created,
+            role.getId());
+      }
+    } catch (Exception e) {
+      log.error("Error granting shared Copilot agents to role '{}': {}",
+          role != null ? role.getId() : null, e.getMessage(), e);
     }
   }
 

--- a/src/com/etendoerp/copilot/util/AgentAccessUtils.java
+++ b/src/com/etendoerp/copilot/util/AgentAccessUtils.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hibernate.criterion.Restrictions;
 import org.openbravo.base.provider.OBProvider;
 import org.openbravo.dal.service.OBCriteria;
@@ -29,6 +31,8 @@ import com.etendoerp.copilot.data.CopilotRoleApp;
  * operation is idempotent and short-circuited so the steady-state cost is a single query.</p>
  */
 public final class AgentAccessUtils {
+
+  private static final Logger log = LogManager.getLogger(AgentAccessUtils.class);
 
   /** Agent scope value "Client" — visible to client-level roles. */
   public static final String SCOPE_CLIENT = "C";
@@ -69,6 +73,26 @@ public final class AgentAccessUtils {
       OBDal.getInstance().flush();
     }
     return created;
+  }
+
+  /**
+   * Grants the shared Copilot agents to {@code role} without ever aborting the caller. Any failure
+   * is logged and swallowed so a grant problem cannot break the assistants listing; the grants are
+   * simply retried on the next load.
+   *
+   * @param role the role requesting its assistants
+   */
+  public static void ensureSharedAgentsGrantedSafely(Role role) {
+    try {
+      int created = ensureSharedAgentsGranted(role);
+      if (created > 0) {
+        log.info("Granted {} shared Copilot agent(s) to client-admin role '{}'", created,
+            role.getId());
+      }
+    } catch (Exception e) {
+      log.error("Error granting shared Copilot agents to role '{}': {}",
+          role != null ? role.getId() : null, e.getMessage(), e);
+    }
   }
 
   /**

--- a/src/com/etendoerp/copilot/util/AgentAccessUtils.java
+++ b/src/com/etendoerp/copilot/util/AgentAccessUtils.java
@@ -1,0 +1,137 @@
+package com.etendoerp.copilot.util;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.criterion.Restrictions;
+import org.openbravo.base.provider.OBProvider;
+import org.openbravo.dal.service.OBCriteria;
+import org.openbravo.dal.service.OBDal;
+import org.openbravo.model.ad.access.Role;
+
+import com.etendoerp.copilot.data.CopilotApp;
+import com.etendoerp.copilot.data.CopilotRoleApp;
+
+/**
+ * Utility for granting shared Copilot agents to a client-admin role.
+ *
+ * <p>An agent is "shared" (visible to every client-admin role) iff its agent scope is
+ * Client-System ({@value #SCOPE_CLIENT_SYSTEM}) or Client ({@value #SCOPE_CLIENT}), it is
+ * flagged to sync on startup, and it is active. System-scope agents are excluded.</p>
+ *
+ * <p>This is invoked lazily from {@code RestServiceUtil.handleAssistants} (the
+ * {@code /sws/copilot/assistants} endpoint) so a client that was onboarded after the last
+ * Tomcat startup — and therefore never got its grants from
+ * {@code CopilotSyncStartup} — receives them the first time it opens Copilot. The role is
+ * fully persistent at request time, so there is no transient-entity problem, and the
+ * operation is idempotent and short-circuited so the steady-state cost is a single query.</p>
+ */
+public final class AgentAccessUtils {
+
+  /** Agent scope value "Client" — visible to client-level roles. */
+  public static final String SCOPE_CLIENT = "C";
+  /** Agent scope value "Client-System" — visible to both system and client-level roles. */
+  public static final String SCOPE_CLIENT_SYSTEM = "CS";
+
+  /** System client id — client-admin roles of the System client are never granted here. */
+  private static final String SYSTEM_CLIENT_ID = "0";
+
+  private AgentAccessUtils() {
+  }
+
+  /**
+   * Grants every missing shared agent to {@code role}, if it is an eligible client-admin role.
+   * Idempotent: existing grants are left untouched. Short-circuited: when the role already has
+   * every shared agent (the steady state) nothing is written and the session is not flushed.
+   *
+   * @param role the role that just requested its assistants
+   * @return the number of new grants created (0 when the role is not eligible or already complete)
+   */
+  public static int ensureSharedAgentsGranted(Role role) {
+    if (!isEligibleRole(role)) {
+      return 0;
+    }
+    List<CopilotApp> shared = getSharedStartupAgents();
+    if (shared.isEmpty()) {
+      return 0;
+    }
+    Set<String> grantedAgentIds = getGrantedAgentIds(role);
+    int created = 0;
+    for (CopilotApp app : shared) {
+      if (!grantedAgentIds.contains(app.getId())) {
+        createGrant(app, role);
+        created++;
+      }
+    }
+    if (created > 0) {
+      OBDal.getInstance().flush();
+    }
+    return created;
+  }
+
+  /**
+   * A role is eligible for shared-agent grants when it is an active client-admin role that does
+   * not belong to the System client.
+   *
+   * @param role the role to test
+   * @return {@code true} when the role should receive the shared agents
+   */
+  private static boolean isEligibleRole(Role role) {
+    return role != null
+        && Boolean.TRUE.equals(role.isClientAdmin())
+        && Boolean.TRUE.equals(role.isActive())
+        && role.getClient() != null
+        && !SYSTEM_CLIENT_ID.equals(role.getClient().getId());
+  }
+
+  /**
+   * Returns every {@link CopilotApp} that must be shared with client-admin roles:
+   * agent scope in ({@value #SCOPE_CLIENT_SYSTEM}, {@value #SCOPE_CLIENT}), sync-on-startup, active.
+   *
+   * @return the list of shared agents (never {@code null})
+   */
+  public static List<CopilotApp> getSharedStartupAgents() {
+    OBCriteria<CopilotApp> crit = OBDal.getInstance().createCriteria(CopilotApp.class);
+    crit.add(Restrictions.in(CopilotApp.PROPERTY_AGENTSCOPE,
+        Arrays.asList(SCOPE_CLIENT_SYSTEM, SCOPE_CLIENT)));
+    crit.add(Restrictions.eq(CopilotApp.PROPERTY_SYNCSTARTUP, Boolean.TRUE));
+    crit.add(Restrictions.eq(CopilotApp.PROPERTY_ACTIVE, Boolean.TRUE));
+    return crit.list();
+  }
+
+  /**
+   * Returns the ids of the agents already granted to {@code role}.
+   *
+   * @param role the role whose grants are read
+   * @return the set of granted {@link CopilotApp} ids (never {@code null})
+   */
+  private static Set<String> getGrantedAgentIds(Role role) {
+    OBCriteria<CopilotRoleApp> crit = OBDal.getInstance().createCriteria(CopilotRoleApp.class);
+    crit.add(Restrictions.eq(CopilotRoleApp.PROPERTY_ROLE, role));
+    Set<String> ids = new HashSet<>();
+    for (CopilotRoleApp roleApp : crit.list()) {
+      if (roleApp.getCopilotApp() != null) {
+        ids.add(roleApp.getCopilotApp().getId());
+      }
+    }
+    return ids;
+  }
+
+  /**
+   * Creates and saves a {@link CopilotRoleApp} grant linking {@code app} to {@code role},
+   * inheriting the role's client and organization.
+   *
+   * @param app  the agent to grant
+   * @param role the role receiving access
+   */
+  private static void createGrant(CopilotApp app, Role role) {
+    CopilotRoleApp roleApp = OBProvider.getInstance().get(CopilotRoleApp.class);
+    roleApp.setClient(role.getClient());
+    roleApp.setOrganization(role.getOrganization());
+    roleApp.setCopilotApp(app);
+    roleApp.setRole(role);
+    OBDal.getInstance().save(roleApp);
+  }
+}


### PR DESCRIPTION
Client-admin roles onboarded after the last Tomcat startup never received
their shared-agent grants from CopilotSyncStartup (which only runs at startup).
Grant them lazily in RestServiceUtil.handleAssistants so the role sees the
shared agents the first time it opens Copilot.

- Add AgentAccessUtils.ensureSharedAgentsGranted(role): grants every missing
  ETCOP_ROLE_APP for agents with AGENT_SCOPE in (CS, C), SYNC_STARTUP = Y, and
  active status to eligible (client-admin, active, non-System) roles.
  Idempotent and short-circuited so the steady state requires only a single
  query.
- Wire it into handleAssistants via grantSharedAgentsSafely, which never
  aborts the listing. Webhook permissions continue to be assigned at
  serve-time.
- Add AgentAccessUtilsTest covering grant, no-op, non-admin skip, and
  System-client skip scenarios.